### PR TITLE
Changed IllegalArgumentException to false

### DIFF
--- a/src/main/java/net/raidstone/wgevents/WorldGuardEvents.java
+++ b/src/main/java/net/raidstone/wgevents/WorldGuardEvents.java
@@ -115,7 +115,7 @@ public class WorldGuardEvents extends JavaPlugin implements Listener {
     public static boolean isPlayerInAllRegions(UUID playerUUID, Set<String> regionNames)
     {
         Set<String> regions = getRegionsNames(playerUUID);
-        if(regions.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        if(regions.isEmpty()) return false; //Player is in NO regions.
         
         return regions.containsAll(regionNames.stream().map(String::toLowerCase).collect(Collectors.toSet()));
     }
@@ -130,7 +130,7 @@ public class WorldGuardEvents extends JavaPlugin implements Listener {
     public static boolean isPlayerInAnyRegion(UUID playerUUID, Set<String> regionNames)
     {
         Set<String> regions = getRegionsNames(playerUUID);
-        if(regions.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        if(regions.isEmpty()) return false; //Player is in NO regions.
         for(String region : regionNames)
         {
             if(regions.contains(region.toLowerCase()))


### PR DESCRIPTION
If the player is in no regions (only `__global__`), it should return false instead of throwing an error.