### PR TITLE
Typo fix. + return false if regions is empty

### DIFF
--- a/src/main/java/net/raidstone/wgevents/WorldGuardEvents.java
+++ b/src/main/java/net/raidstone/wgevents/WorldGuardEvents.java
@@ -114,8 +114,9 @@ public class WorldGuardEvents extends JavaPlugin implements Listener {
      */
     public static boolean isPlayerInAllRegions(UUID playerUUID, Set<String> regionNames)
     {
-        Set<String> regions = getRegionsNames(playerUUID);
         if(regionNames.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        
+        Set<String> regions = getRegionsNames(playerUUID);
         if(regions.isEmpty()) return false;
         
         return regions.containsAll(regionNames.stream().map(String::toLowerCase).collect(Collectors.toSet()));
@@ -130,8 +131,9 @@ public class WorldGuardEvents extends JavaPlugin implements Listener {
      */
     public static boolean isPlayerInAnyRegion(UUID playerUUID, Set<String> regionNames)
     {
-        Set<String> regions = getRegionsNames(playerUUID);
         if(regionNames.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        
+        Set<String> regions = getRegionsNames(playerUUID);
         if(regions.isEmpty()) return false;
         
         for(String region : regionNames)

--- a/src/main/java/net/raidstone/wgevents/WorldGuardEvents.java
+++ b/src/main/java/net/raidstone/wgevents/WorldGuardEvents.java
@@ -115,7 +115,8 @@ public class WorldGuardEvents extends JavaPlugin implements Listener {
     public static boolean isPlayerInAllRegions(UUID playerUUID, Set<String> regionNames)
     {
         Set<String> regions = getRegionsNames(playerUUID);
-        if(regions.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        if(regionNames.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        if(regions.isEmpty()) return false;
         
         return regions.containsAll(regionNames.stream().map(String::toLowerCase).collect(Collectors.toSet()));
     }
@@ -130,7 +131,9 @@ public class WorldGuardEvents extends JavaPlugin implements Listener {
     public static boolean isPlayerInAnyRegion(UUID playerUUID, Set<String> regionNames)
     {
         Set<String> regions = getRegionsNames(playerUUID);
-        if(regions.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        if(regionNames.isEmpty()) throw new IllegalArgumentException("You need to check for at least one region !");
+        if(regions.isEmpty()) return false;
+        
         for(String region : regionNames)
         {
             if(regions.contains(region.toLowerCase()))


### PR DESCRIPTION
Problem: 
If a player doesn't have any regions it will throw a error. 
Solved: I have changed check to regionNames instead of regions and made it return false if a players regions is empty.